### PR TITLE
Allow choosing between comments/article to share

### DIFF
--- a/app/src/main/java/io/github/hidroh/materialistic/BaseListActivity.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/BaseListActivity.java
@@ -5,17 +5,17 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.graphics.PorterDuff;
 import android.os.Bundle;
 import android.support.annotation.LayoutRes;
 import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentStatePagerAdapter;
-import android.support.v4.view.MenuItemCompat;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.SearchView;
-import android.support.v7.widget.ShareActionProvider;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -43,6 +43,7 @@ public abstract class BaseListActivity extends DrawerActivity implements MultiPa
     private ViewPager mViewPager;
     private CoordinatorLayout mContentView;
     @Inject ActionViewResolver mActionViewResolver;
+    @Inject AlertDialogBuilder mAlertDialogBuilder;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -120,6 +121,11 @@ public abstract class BaseListActivity extends DrawerActivity implements MultiPa
     public boolean onCreateOptionsMenu(Menu menu) {
         if (getResources().getBoolean(R.bool.multi_pane)) {
             getMenuInflater().inflate(R.menu.menu_list_land, menu);
+            menu.findItem(R.id.menu_share).getIcon()
+                    .mutate()
+                    .setColorFilter(ContextCompat.getColor(this,
+                                    AppUtils.getThemedResId(this, android.R.attr.textColorPrimary)),
+                            PorterDuff.Mode.SRC_IN);
         }
 
         if (isSearchable()) {
@@ -144,14 +150,6 @@ public abstract class BaseListActivity extends DrawerActivity implements MultiPa
         menu.findItem(R.id.menu_comment).setVisible(isItemOptionsMenuVisible() && mStoryMode);
         menu.findItem(R.id.menu_story).setVisible(isItemOptionsMenuVisible() && !mStoryMode);
         menu.findItem(R.id.menu_share).setVisible(isItemOptionsMenuVisible());
-        if (mSelectedItem != null && mSelectedItem.isShareable()) {
-            ShareActionProvider shareActionProvider = (ShareActionProvider) MenuItemCompat.getActionProvider(
-                    menu.findItem(R.id.menu_share));
-            shareActionProvider.setShareIntent(AppUtils.makeShareIntent(
-                    getString(R.string.share_format,
-                            mSelectedItem.getDisplayedTitle(),
-                            mSelectedItem.getUrl())));
-        }
         return isSearchable() || super.onPrepareOptionsMenu(menu);
     }
 
@@ -164,7 +162,10 @@ public abstract class BaseListActivity extends DrawerActivity implements MultiPa
             supportInvalidateOptionsMenu();
             return true;
         }
-
+        if (item.getItemId() == R.id.menu_share) {
+            AppUtils.share(BaseListActivity.this, mAlertDialogBuilder, mSelectedItem);
+            return true;
+        }
         return super.onOptionsItemSelected(item);
     }
 

--- a/app/src/main/java/io/github/hidroh/materialistic/ItemActivity.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/ItemActivity.java
@@ -3,16 +3,16 @@ package io.github.hidroh.materialistic;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.graphics.PorterDuff;
 import android.os.Bundle;
 import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.Snackbar;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentPagerAdapter;
-import android.support.v4.view.MenuItemCompat;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
-import android.support.v7.widget.ShareActionProvider;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.view.Menu;
@@ -114,6 +114,11 @@ public class ItemActivity extends BaseItemActivity implements Scrollable {
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu_share, menu);
+        menu.findItem(R.id.menu_share).getIcon()
+                .mutate()
+                .setColorFilter(ContextCompat.getColor(this,
+                        AppUtils.getThemedResId(this, android.R.attr.textColorPrimary)),
+                        PorterDuff.Mode.SRC_IN);
         getMenuInflater().inflate(R.menu.menu_item, menu);
         return super.onCreateOptionsMenu(menu);
     }
@@ -121,15 +126,6 @@ public class ItemActivity extends BaseItemActivity implements Scrollable {
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         menu.findItem(R.id.menu_share).setVisible(mItem != null);
-        if (mItem != null) {
-            String url = mTabLayout.getSelectedTabPosition() == 0 ?
-                    String.format(HackerNewsClient.WEB_ITEM_PATH, mItem.getId()) :
-                    mItem.getUrl();
-            ((ShareActionProvider) MenuItemCompat.getActionProvider(
-                    menu.findItem(R.id.menu_share)))
-                    .setShareIntent(AppUtils.makeShareIntent(
-                            getString(R.string.share_format, mItem.getDisplayedTitle(), url)));
-        }
         return mItem != null;
     }
 
@@ -155,7 +151,10 @@ public class ItemActivity extends BaseItemActivity implements Scrollable {
                     .show();
             return true;
         }
-
+        if (item.getItemId() == R.id.menu_share) {
+            AppUtils.share(ItemActivity.this, mAlertDialogBuilder, mItem);
+            return true;
+        }
         return super.onOptionsItemSelected(item);
     }
 
@@ -298,12 +297,6 @@ public class ItemActivity extends BaseItemActivity implements Scrollable {
         });
         mTabLayout.setupWithViewPager(viewPager);
         mTabLayout.setOnTabSelectedListener(new TabLayout.ViewPagerOnTabSelectedListener(viewPager) {
-            @Override
-            public void onTabSelected(TabLayout.Tab tab) {
-                super.onTabSelected(tab);
-                supportInvalidateOptionsMenu();
-            }
-
             @Override
             public void onTabReselected(TabLayout.Tab tab) {
                 Fragment activeFragment = fragments[viewPager.getCurrentItem()];

--- a/app/src/main/res/menu-w820dp-land/menu_list_land.xml
+++ b/app/src/main/res/menu-w820dp-land/menu_list_land.xml
@@ -12,6 +12,6 @@
         app:showAsAction="always" />
     <item android:id="@id/menu_share"
         android:title="@string/share"
-        app:showAsAction="ifRoom"
-        app:actionProviderClass="android.support.v7.widget.ShareActionProvider" />
+        android:icon="@drawable/ic_share_grey600_24dp"
+        app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/menu/menu_share.xml
+++ b/app/src/main/res/menu/menu_share.xml
@@ -4,6 +4,6 @@
     <item
         android:id="@id/menu_share"
         android:title="@string/share"
-        app:actionProviderClass="android.support.v7.widget.ShareActionProvider"
+        android:icon="@drawable/ic_share_grey600_24dp"
         app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,6 @@
     <string name="open_drawer">Open drawer</string>
     <string name="close_drawer">Close drawer</string>
     <string name="view_in_browser">View in external browser</string>
-    <string name="share_format" formatted="false">%s - %s (via Materialistic)</string>
     <string name="favorite_email_subject">Your Materialistic saved stories</string>
     <string name="share">Share</string>
     <string name="title_activity_about">About</string>

--- a/app/src/test/java/io/github/hidroh/materialistic/AppUtilsTest.java
+++ b/app/src/test/java/io/github/hidroh/materialistic/AppUtilsTest.java
@@ -27,14 +27,6 @@ import static org.robolectric.Shadows.shadowOf;
 @RunWith(RobolectricGradleTestRunner.class)
 public class AppUtilsTest {
     @Test
-    public void testMakeShareIntent() {
-        Intent actual = AppUtils.makeShareIntent("content");
-        assertThat(actual).hasAction(Intent.ACTION_SEND)
-                .hasType("text/plain")
-                .hasExtra(Intent.EXTRA_TEXT, "content");
-    }
-
-    @Test
     public void testSetTextWithLinks() {
         TextView textView = new TextView(RuntimeEnvironment.application);
         AppUtils.setTextWithLinks(textView, "<a href=\\\"http://www.justin.tv/problems/bml\\\" rel=\\\"nofollow\\\">http://www.justin.tv/problems/bml</a>");

--- a/app/src/test/java/io/github/hidroh/materialistic/BaseListActivityLandTest.java
+++ b/app/src/test/java/io/github/hidroh/materialistic/BaseListActivityLandTest.java
@@ -1,5 +1,7 @@
 package io.github.hidroh.materialistic;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.support.v4.view.ViewPager;
 
 import org.junit.After;
@@ -10,6 +12,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowAlertDialog;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowLooper;
 import org.robolectric.util.ActivityController;
@@ -18,6 +21,7 @@ import io.github.hidroh.materialistic.test.ShadowSupportPreferenceManager;
 import io.github.hidroh.materialistic.test.TestListActivity;
 import io.github.hidroh.materialistic.test.TestWebItem;
 
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
@@ -25,8 +29,7 @@ import static org.assertj.android.api.Assertions.assertThat;
 import static org.assertj.android.support.v4.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-// TODO switch to API 21 once ShareActionProvider is fixed
-@Config(qualifiers = "w820dp-land", sdk = 19, shadows = {ShadowSupportPreferenceManager.class})
+@Config(qualifiers = "w820dp-land", shadows = {ShadowSupportPreferenceManager.class})
 @RunWith(RobolectricGradleTestRunner.class)
 public class BaseListActivityLandTest {
     private ActivityController<TestListActivity> controller;
@@ -85,6 +88,12 @@ public class BaseListActivityLandTest {
         });
         assertThat(activity.findViewById(R.id.empty)).isNotVisible();
         assertStoryMode();
+        shadowOf(activity).clickMenuItem(R.id.menu_share);
+        AlertDialog alertDialog = ShadowAlertDialog.getLatestAlertDialog();
+        assertNotNull(alertDialog);
+        assertEquals(activity.getString(R.string.share), shadowOf(alertDialog).getMessage());
+        assertThat(alertDialog.getButton(DialogInterface.BUTTON_POSITIVE)).hasText(R.string.article);
+        assertThat(alertDialog.getButton(DialogInterface.BUTTON_NEGATIVE)).hasText(R.string.comments);
     }
 
     @Test

--- a/app/src/test/java/io/github/hidroh/materialistic/BaseListActivityTest.java
+++ b/app/src/test/java/io/github/hidroh/materialistic/BaseListActivityTest.java
@@ -31,8 +31,7 @@ import static org.assertj.android.api.Assertions.assertThat;
 import static org.assertj.android.appcompat.v7.api.Assertions.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
-// TODO switch to API 21 once ShareActionProvider is fixed
-@Config(sdk = 19, shadows = {ShadowSupportPreferenceManager.class, ShadowRecyclerView.class})
+@Config(shadows = {ShadowSupportPreferenceManager.class, ShadowRecyclerView.class})
 @RunWith(RobolectricGradleTestRunner.class)
 public class BaseListActivityTest {
     private ActivityController<TestListActivity> controller;

--- a/app/src/test/java/io/github/hidroh/materialistic/WebFragmentTest.java
+++ b/app/src/test/java/io/github/hidroh/materialistic/WebFragmentTest.java
@@ -40,8 +40,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
-// TODO switch to API 21 once ShareActionProvider is fixed
-@Config(shadows = {ShadowWebView.class, ShadowNestedScrollView.class}, sdk = 19)
+@Config(shadows = {ShadowWebView.class, ShadowNestedScrollView.class})
 @RunWith(RobolectricGradleTestRunner.class)
 public class WebFragmentTest {
     private WebActivity activity;


### PR DESCRIPTION
This will slightly regress #44 but is needed to intercept sharing flow and ask users which one to share between article & comments. On Lollipop and above the UI will show nice bottom sheet design for share targets. Before Lollipop will show a system dialog.