### PR TITLE
Fix visible-create order

### DIFF
--- a/app/src/main/java/io/github/hidroh/materialistic/LazyLoadFragment.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/LazyLoadFragment.java
@@ -23,8 +23,7 @@ import android.os.Bundle;
  */
 public abstract class LazyLoadFragment extends BaseFragment {
     private static final String STATE_EAGER_LOAD = "state:eagerLoad";
-    private boolean mEagerLoad;
-    private boolean mActivityCreated;
+    private boolean mEagerLoad, mVisible, mActivityCreated;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -39,8 +38,8 @@ public abstract class LazyLoadFragment extends BaseFragment {
     @Override
     public void setUserVisibleHint(boolean isVisibleToUser) {
         super.setUserVisibleHint(isVisibleToUser);
-        if (isVisibleToUser && !mEagerLoad) {
-            mEagerLoad = true;
+        if (isVisibleToUser && !mVisible) {
+            mVisible = true;
             eagerLoad();
         }
     }
@@ -64,12 +63,8 @@ public abstract class LazyLoadFragment extends BaseFragment {
     protected abstract void load();
 
     final void eagerLoad() {
-        if (!mEagerLoad) {
-            return;
+        if (mActivityCreated && (mEagerLoad || mVisible)) {
+            load();
         }
-        if (!mActivityCreated) {
-            return;
-        }
-        load();
     }
 }

--- a/app/src/main/res/layout/fragment_web.xml
+++ b/app/src/main/res/layout/fragment_web.xml
@@ -54,6 +54,8 @@
 
                 <io.github.hidroh.materialistic.widget.CacheableWebView
                     android:id="@id/web_view"
+                    android:scrollbarStyle="insideOverlay"
+                    android:scrollbars="vertical"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content" />
 


### PR DESCRIPTION
The assumption that `setUserVisibleHint` would be triggered after `onCreate` no longer holds for support library 24, where `setUserVisibleHint` could be triggered before `onCreate`.