### PR TITLE
Avoid casting View's Context

### DIFF
--- a/app/src/main/java/io/github/hidroh/materialistic/BaseListFragment.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/BaseListFragment.java
@@ -87,6 +87,7 @@ abstract class BaseListFragment extends LazyLoadFragment implements Scrollable {
         super.onActivityCreated(savedInstanceState);
         if (isNewInstance()) {
             getAdapter().setCustomTabsDelegate(mCustomTabsDelegate);
+            getAdapter().attach((Injectable) getActivity(), (MultiPaneListener) getActivity());
             mRecyclerView.setAdapter(getAdapter());
             mScrollableHelper = new KeyDelegate.RecyclerViewHelper(mRecyclerView,
                     KeyDelegate.RecyclerViewHelper.SCROLL_PAGE);

--- a/app/src/main/java/io/github/hidroh/materialistic/ItemFragment.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/ItemFragment.java
@@ -233,6 +233,7 @@ public class ItemFragment extends LazyLoadFragment implements Scrollable, Naviga
 
         mEmptyView.setVisibility(View.GONE);
         String displayOption = Preferences.getCommentDisplayOption(getActivity());
+        Injectable injectable = (Injectable) getActivity();
         if (Preferences.isSinglePage(getActivity(), displayOption)) {
             boolean autoExpand = Preferences.isAutoExpand(getActivity(), displayOption);
             // if collapsed or no saved state then start a fresh (adapter items all collapsed)
@@ -240,9 +241,9 @@ public class ItemFragment extends LazyLoadFragment implements Scrollable, Naviga
                 mAdapterItems = new SinglePageItemRecyclerViewAdapter.SavedState(
                         new ArrayList<>(Arrays.asList(mItem.getKidItems())));
             }
-            mAdapter = new SinglePageItemRecyclerViewAdapter(mItemManager, mAdapterItems, autoExpand);
+            mAdapter = new SinglePageItemRecyclerViewAdapter(injectable, mItemManager, mAdapterItems, autoExpand);
         } else {
-            mAdapter = new MultiPageItemRecyclerViewAdapter(mItemManager, mItem.getKidItems());
+            mAdapter = new MultiPageItemRecyclerViewAdapter(injectable, mItemManager, mItem.getKidItems());
         }
         mAdapter.setCacheMode(mCacheMode);
         mAdapter.initDisplayOptions(getActivity());

--- a/app/src/main/java/io/github/hidroh/materialistic/ThreadPreviewActivity.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/ThreadPreviewActivity.java
@@ -56,7 +56,7 @@ public class ThreadPreviewActivity extends InjectableActivity {
         RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
         recyclerView.setLayoutManager(new SnappyLinearLayoutManager(this, false));
         recyclerView.addItemDecoration(new CommentItemDecoration(this));
-        recyclerView.setAdapter(new ThreadPreviewRecyclerViewAdapter(mItemManager, item));
+        recyclerView.setAdapter(new ThreadPreviewRecyclerViewAdapter(this, mItemManager, item));
         mKeyDelegate.setScrollable(
                 new KeyDelegate.RecyclerViewHelper(recyclerView,
                         KeyDelegate.RecyclerViewHelper.SCROLL_ITEM), null);

--- a/app/src/main/java/io/github/hidroh/materialistic/UserActivity.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/UserActivity.java
@@ -240,7 +240,7 @@ public class UserActivity extends InjectableActivity implements Scrollable {
         int count = mUser.getItems().length;
         mTabLayout.addTab(mTabLayout.newTab()
                 .setText(getResources().getQuantityString(R.plurals.submissions_count, count, count)));
-        mRecyclerView.setAdapter(new SubmissionRecyclerViewAdapter(mItemManger, mUser.getItems()));
+        mRecyclerView.setAdapter(new SubmissionRecyclerViewAdapter(this, mItemManger, mUser.getItems()));
         mRecyclerView.setLayoutFrozen(mBottomSheetBehavior.getState() !=
                 BottomSheetBehavior.STATE_EXPANDED);
     }

--- a/app/src/main/java/io/github/hidroh/materialistic/widget/ItemRecyclerViewAdapter.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/widget/ItemRecyclerViewAdapter.java
@@ -75,17 +75,15 @@ public abstract class ItemRecyclerViewAdapter<VH extends ItemRecyclerViewAdapter
         void onPosition(int position);
     }
 
-    ItemRecyclerViewAdapter(ItemManager itemManager) {
+    ItemRecyclerViewAdapter(Injectable injectable, ItemManager itemManager) {
         mItemManager = itemManager;
+        injectable.inject(this);
     }
 
     @Override
     public void onAttachedToRecyclerView(RecyclerView recyclerView) {
         super.onAttachedToRecyclerView(recyclerView);
         mContext = recyclerView.getContext();
-        if (mContext instanceof Injectable) {
-            ((Injectable) mContext).inject(this);
-        }
         mLayoutInflater = AppUtils.createLayoutInflater(mContext);
         TypedArray ta = mContext.obtainStyledAttributes(new int[]{
                 android.R.attr.textColorTertiary,

--- a/app/src/main/java/io/github/hidroh/materialistic/widget/ListRecyclerViewAdapter.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/widget/ListRecyclerViewAdapter.java
@@ -75,8 +75,6 @@ public abstract class ListRecyclerViewAdapter
         mRecyclerView = recyclerView;
         mContext = recyclerView.getContext();
         mInflater = AppUtils.createLayoutInflater(mContext);
-        ((Injectable) mContext).inject(this);
-        mMultiPaneListener = (MultiPaneListener) mContext;
         mCardElevation = mContext.getResources()
                 .getDimensionPixelSize(R.dimen.cardview_default_elevation);
         mMultiWindowEnabled = Preferences.multiWindowEnabled(mContext);
@@ -130,6 +128,11 @@ public abstract class ListRecyclerViewAdapter
     @Override
     public final long getItemId(int position) {
         return getItem(position).getLongId();
+    }
+
+    public void attach(Injectable injectable, MultiPaneListener multiPaneListener) {
+        injectable.inject(this);
+        mMultiPaneListener = multiPaneListener;
     }
 
     public final boolean isCardViewEnabled() {
@@ -230,7 +233,7 @@ public abstract class ListRecyclerViewAdapter
                 .putExtra(ItemActivity.EXTRA_ITEM, item)
                 .putExtra(ItemActivity.EXTRA_OPEN_COMMENTS, true);
         mContext.startActivity(mMultiWindowEnabled ?
-                AppUtils.multiWindowIntent((Activity) mContext, intent) : intent);
+                AppUtils.multiWindowIntent((Activity) mContext, intent) : intent); // TODO avoid casting context
     }
 
     /**

--- a/app/src/main/java/io/github/hidroh/materialistic/widget/MultiPageItemRecyclerViewAdapter.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/widget/MultiPageItemRecyclerViewAdapter.java
@@ -22,6 +22,7 @@ import android.view.ViewGroup;
 
 import java.util.Arrays;
 
+import io.github.hidroh.materialistic.Injectable;
 import io.github.hidroh.materialistic.ItemActivity;
 import io.github.hidroh.materialistic.R;
 import io.github.hidroh.materialistic.data.Item;
@@ -32,8 +33,8 @@ public class MultiPageItemRecyclerViewAdapter
     private static final int VIEW_TYPE_FOOTER = -1;
     private final Item[] mItems;
 
-    public MultiPageItemRecyclerViewAdapter(ItemManager itemManager, Item[] items) {
-        super(itemManager);
+    public MultiPageItemRecyclerViewAdapter(Injectable injectable, ItemManager itemManager, Item[] items) {
+        super(injectable, itemManager);
         mItems = Arrays.copyOf(items, items.length + 1);
         mItems[items.length] = null; // footer
     }

--- a/app/src/main/java/io/github/hidroh/materialistic/widget/SinglePageItemRecyclerViewAdapter.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/widget/SinglePageItemRecyclerViewAdapter.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import io.github.hidroh.materialistic.AppUtils;
+import io.github.hidroh.materialistic.Injectable;
 import io.github.hidroh.materialistic.Navigable;
 import io.github.hidroh.materialistic.Preferences;
 import io.github.hidroh.materialistic.R;
@@ -67,10 +68,11 @@ public class SinglePageItemRecyclerViewAdapter
     private ItemTouchHelper mItemTouchHelper;
     private int[] mLock;
 
-    public SinglePageItemRecyclerViewAdapter(ItemManager itemManager,
+    public SinglePageItemRecyclerViewAdapter(Injectable injectable,
+                                             ItemManager itemManager,
                                              @NonNull SavedState state,
                                              boolean autoExpand) {
-        super(itemManager);
+        super(injectable, itemManager);
         this.mState = state;
         mAutoExpand = autoExpand;
     }

--- a/app/src/main/java/io/github/hidroh/materialistic/widget/SubmissionRecyclerViewAdapter.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/widget/SubmissionRecyclerViewAdapter.java
@@ -22,6 +22,7 @@ import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewGroup;
 
+import io.github.hidroh.materialistic.Injectable;
 import io.github.hidroh.materialistic.ItemActivity;
 import io.github.hidroh.materialistic.R;
 import io.github.hidroh.materialistic.ThreadPreviewActivity;
@@ -31,8 +32,8 @@ import io.github.hidroh.materialistic.data.ItemManager;
 public class SubmissionRecyclerViewAdapter extends ItemRecyclerViewAdapter<SubmissionViewHolder> {
     private final Item[] mItems;
 
-    public SubmissionRecyclerViewAdapter(ItemManager itemManager, @NonNull Item[] items) {
-        super(itemManager);
+    public SubmissionRecyclerViewAdapter(Injectable injectable, ItemManager itemManager, @NonNull Item[] items) {
+        super(injectable, itemManager);
         mItems = items;
     }
 

--- a/app/src/main/java/io/github/hidroh/materialistic/widget/ThreadPreviewRecyclerViewAdapter.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/widget/ThreadPreviewRecyclerViewAdapter.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.github.hidroh.materialistic.AppUtils;
+import io.github.hidroh.materialistic.Injectable;
 import io.github.hidroh.materialistic.ItemActivity;
 import io.github.hidroh.materialistic.R;
 import io.github.hidroh.materialistic.data.Item;
@@ -38,8 +39,8 @@ public class ThreadPreviewRecyclerViewAdapter extends ItemRecyclerViewAdapter<Su
     private int mLevelIndicatorWidth;
     private final String mUsername;
 
-    public ThreadPreviewRecyclerViewAdapter(ItemManager itemManager, Item item) {
-        super(itemManager);
+    public ThreadPreviewRecyclerViewAdapter(Injectable injectable, ItemManager itemManager, Item item) {
+        super(injectable, itemManager);
         mItems.add(item);
         mUsername = item.getBy();
     }


### PR DESCRIPTION
Retained views still refer to the old Context, which would be a destroyed Activity, but sufficient for its rendering.