### PR TITLE
Give export file a descriptive name

### DIFF
--- a/app/src/main/java/io/github/hidroh/materialistic/data/FavoriteManager.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/data/FavoriteManager.java
@@ -67,7 +67,7 @@ public class FavoriteManager implements LocalItemManager<Favorite> {
     private static final String URI_PATH_CLEAR = "clear";
     @VisibleForTesting static final String FILE_AUTHORITY = "io.github.hidroh.materialistic.fileprovider";
     private static final String PATH_SAVED = "saved";
-    private static final String FILENAME_EXPORT = "export.txt";
+    private static final String FILENAME_EXPORT = "materialistic-export.txt";
     private final Scheduler mIoScheduler;
     @Synthetic Cursor mCursor;
     private final int mNotificationId = Long.valueOf(System.currentTimeMillis()).intValue();

--- a/app/src/test/java/io/github/hidroh/materialistic/data/FavoriteManagerTest.java
+++ b/app/src/test/java/io/github/hidroh/materialistic/data/FavoriteManagerTest.java
@@ -70,7 +70,7 @@ public class FavoriteManagerTest {
         manager = new FavoriteManager(Schedulers.immediate()) {
             @Override
             protected Uri getUriForFile(Context context, File file) {
-                return Uri.parse("content://" + FavoriteManager.FILE_AUTHORITY + "/files/saved/export.txt");
+                return Uri.parse("content://" + FavoriteManager.FILE_AUTHORITY + "/files/saved/materialistic-export.txt");
             }
         };
     }


### PR DESCRIPTION
Avoid "export.txt", a generic name that makes future searches harder.

https://www.xkcd.com/1459/