### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/app/src/test/java/io/github/hidroh/materialistic/data/FavoriteManagerTest.java
+++ b/app/src/test/java/io/github/hidroh/materialistic/data/FavoriteManagerTest.java
@@ -219,6 +219,9 @@ public class FavoriteManagerTest {
         parcel.writeString("title");
         parcel.setDataPosition(0);
         Favorite favorite = Favorite.CREATOR.createFromParcel(parcel);
+		if (parcel != null) {
+			parcel.recycle();
+		}
         assertEquals("title", favorite.getDisplayedTitle());
         assertEquals("example.com", favorite.getSource());
         assertEquals("http://example.com", favorite.getUrl());
@@ -232,6 +235,9 @@ public class FavoriteManagerTest {
         favorite.writeToParcel(output, 0);
         output.setDataPosition(0);
         assertEquals("1", output.readString());
+		if (output != null) {
+			output.recycle();
+		}
         assertThat(Favorite.CREATOR.newArray(1)).hasSize(1);
     }
 }

--- a/app/src/test/java/io/github/hidroh/materialistic/data/HackerNewsItemTest.java
+++ b/app/src/test/java/io/github/hidroh/materialistic/data/HackerNewsItemTest.java
@@ -398,12 +398,18 @@ public class HackerNewsItemTest {
         item.populate(new TestItem() {
             @Override
             public String getTitle() {
-                return "title";
+                if (parcel != null) {
+					parcel.recycle();
+				}
+				return "title";
             }
         });
         item.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
         Item actual = HackerNewsItem.CREATOR.createFromParcel(parcel);
+		if (parcel != null) {
+			parcel.recycle();
+		}
         assertEquals("title", actual.getDisplayedTitle());
         assertFalse(actual.isFavorite());
     }
@@ -417,6 +423,9 @@ public class HackerNewsItemTest {
         item.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
         assertTrue(HackerNewsItem.CREATOR.createFromParcel(parcel).isFavorite());
+		if (parcel != null) {
+			parcel.recycle();
+		}
     }
 
     @Test

--- a/app/src/test/java/io/github/hidroh/materialistic/data/UserItemTest.java
+++ b/app/src/test/java/io/github/hidroh/materialistic/data/UserItemTest.java
@@ -31,6 +31,9 @@ public class UserItemTest {
         parcel.setDataPosition(0);
 
         UserItem actualRead = UserItem.CREATOR.createFromParcel(parcel);
+		if (parcel != null) {
+			parcel.recycle();
+		}
         assertEquals("username", actualRead.getId());
         assertNotNull(actualRead.getCreated(RuntimeEnvironment.application));
         assertEquals(3, actualRead.getKarma());
@@ -50,5 +53,8 @@ public class UserItemTest {
         assertEquals("about", actualWrite.readString());
         assertThat(actualWrite.createIntArray()).hasSize(3);
         assertThat(actualWrite.createTypedArray(HackerNewsItem.CREATOR)).hasSize(3);
+		if (actualWrite != null) {
+			actualWrite.recycle();
+		}
     }
 }


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary. 

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis