### PR TITLE
Fix the progress bar for the PDF documents

### DIFF
--- a/app/src/main/assets/pdf/script.js
+++ b/app/src/main/assets/pdf/script.js
@@ -31,6 +31,7 @@
     }).then(function (pdfDocument) {
       pdfViewer.setDocument(pdfDocument);
       pdfLinkService.setDocument(pdfDocument, null);
+      PdfAndroidJavascriptBridge.onLoad();
     }).catch(function (e) {
       console.error(e);
       PdfAndroidJavascriptBridge.onFailure();

--- a/app/src/main/java/io/github/hidroh/materialistic/WebFragment.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/WebFragment.java
@@ -314,18 +314,18 @@ public class WebFragment extends LazyLoadFragment
             mWebView.removeJavascriptInterface("PdfAndroidJavascriptBridge");
         }
         if (pdfFilePath != null && isPdfRenderingSupported() && TextUtils.equals(PDF_LOADER_URL, url)) {
-            mProgressBar.setProgress(80);
+            setProgress(80);
             mIsPdf = true;
             mPdfAndroidJavascriptBridge = new PdfAndroidJavascriptBridge(pdfFilePath, new PdfAndroidJavascriptBridge.Callbacks() {
                 @Override
                 public void onFailure() {
                     offerExternalApp();
+                    setProgress(100);
                 }
 
                 @Override
                 public void onLoad() {
-                    mProgressBar.setProgress(100);
-                    mProgressBar.setVisibility(GONE);
+                    setProgress(100);
                 }
             });
             mWebView.addJavascriptInterface(mPdfAndroidJavascriptBridge, "PdfAndroidJavascriptBridge");
@@ -447,10 +447,7 @@ public class WebFragment extends LazyLoadFragment
             public void onProgressChanged(android.webkit.WebView view, int newProgress) {
                 super.onProgressChanged(view, newProgress);
                 if (!mIsPdf) {
-                    mProgressBar.setProgress(newProgress);
-                    mProgressBar.setVisibility(newProgress == 100 ? GONE : VISIBLE);
-                    mButtonRefresh.setImageResource(newProgress == 100 ?
-                            R.drawable.ic_refresh_white_24dp : R.drawable.ic_clear_white_24dp);
+                    setProgress(newProgress);
                 }
             }
         });
@@ -459,8 +456,7 @@ public class WebFragment extends LazyLoadFragment
                 return;
             }
             if (isPdfRenderingSupported() && mimetype.equals(PDF_MIME_TYPE)) {
-                mProgressBar.setVisibility(VISIBLE);
-                mProgressBar.setProgress(10);
+                setProgress(10);
                 mIsPdf = true;
                 downloadFileAndRenderPdf();
             } else {
@@ -479,6 +475,13 @@ public class WebFragment extends LazyLoadFragment
         mWebView.setVisibility(GONE);
         getActivity().findViewById(R.id.empty).setVisibility(VISIBLE);
         getActivity().findViewById(R.id.download_button).setOnClickListener(v -> startActivity(intent));
+    }
+
+    private void setProgress(int progress) {
+        mProgressBar.setProgress(progress);
+        mProgressBar.setVisibility(progress == 100 ? GONE : VISIBLE);
+        mButtonRefresh.setImageResource(progress == 100 ?
+                R.drawable.ic_refresh_white_24dp : R.drawable.ic_clear_white_24dp);
     }
 
     @SuppressLint("SetJavaScriptEnabled")

--- a/app/src/main/java/io/github/hidroh/materialistic/WebFragment.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/WebFragment.java
@@ -103,6 +103,7 @@ public class WebFragment extends LazyLoadFragment
     private View mButtonNext;
     protected ProgressBar mProgressBar;
     private boolean mFullscreen;
+    private boolean mIsPdf;
     protected String mContent;
     private AppUtils.SystemUiHelper mSystemUiHelper;
     private View mFragmentView;
@@ -307,12 +308,26 @@ public class WebFragment extends LazyLoadFragment
 
     @SuppressLint("AddJavascriptInterface")
     private void reloadUrl(String url, @Nullable String pdfFilePath) {
+        mIsPdf = false;
         if (mPdfAndroidJavascriptBridge != null) {
             mPdfAndroidJavascriptBridge.cleanUp();
             mWebView.removeJavascriptInterface("PdfAndroidJavascriptBridge");
         }
         if (pdfFilePath != null && isPdfRenderingSupported() && TextUtils.equals(PDF_LOADER_URL, url)) {
-            mPdfAndroidJavascriptBridge = new PdfAndroidJavascriptBridge(pdfFilePath, this::offerExternalApp);
+            mProgressBar.setProgress(80);
+            mIsPdf = true;
+            mPdfAndroidJavascriptBridge = new PdfAndroidJavascriptBridge(pdfFilePath, new PdfAndroidJavascriptBridge.Callbacks() {
+                @Override
+                public void onFailure() {
+                    offerExternalApp();
+                }
+
+                @Override
+                public void onLoad() {
+                    mProgressBar.setProgress(100);
+                    mProgressBar.setVisibility(GONE);
+                }
+            });
             mWebView.addJavascriptInterface(mPdfAndroidJavascriptBridge, "PdfAndroidJavascriptBridge");
             mWebView.setInitialScale(1);
         }
@@ -431,10 +446,12 @@ public class WebFragment extends LazyLoadFragment
             @Override
             public void onProgressChanged(android.webkit.WebView view, int newProgress) {
                 super.onProgressChanged(view, newProgress);
-                mProgressBar.setProgress(newProgress);
-                mProgressBar.setVisibility(newProgress == 100 ? GONE : VISIBLE);
-                mButtonRefresh.setImageResource(newProgress == 100 ?
-                        R.drawable.ic_refresh_white_24dp : R.drawable.ic_clear_white_24dp);
+                if (!mIsPdf) {
+                    mProgressBar.setProgress(newProgress);
+                    mProgressBar.setVisibility(newProgress == 100 ? GONE : VISIBLE);
+                    mButtonRefresh.setImageResource(newProgress == 100 ?
+                            R.drawable.ic_refresh_white_24dp : R.drawable.ic_clear_white_24dp);
+                }
             }
         });
         mWebView.setDownloadListener((url, userAgent, contentDisposition, mimetype, contentLength) -> {
@@ -442,6 +459,9 @@ public class WebFragment extends LazyLoadFragment
                 return;
             }
             if (isPdfRenderingSupported() && mimetype.equals(PDF_MIME_TYPE)) {
+                mProgressBar.setVisibility(VISIBLE);
+                mProgressBar.setProgress(10);
+                mIsPdf = true;
                 downloadFileAndRenderPdf();
             } else {
                 offerExternalApp();
@@ -639,11 +659,13 @@ public class WebFragment extends LazyLoadFragment
     static class PdfAndroidJavascriptBridge {
         private File mFile;
         private @Nullable RandomAccessFile mRandomAccessFile;
-        private @Nullable PdfAndroidJavascriptBridgeFailureCallback mOnFailure;
+        private @Nullable Callbacks mCallback;
+        private Handler mHandler;
 
-        PdfAndroidJavascriptBridge(String filePath, @Nullable PdfAndroidJavascriptBridgeFailureCallback onFailure) {
+        PdfAndroidJavascriptBridge(String filePath, @Nullable Callbacks callback) {
             mFile = new File(filePath);
-            mOnFailure = onFailure;
+            mCallback = callback;
+            mHandler = new Handler(Looper.getMainLooper());
         }
 
         @JavascriptInterface
@@ -673,9 +695,16 @@ public class WebFragment extends LazyLoadFragment
         }
 
         @JavascriptInterface
+        public void onLoad() {
+            if (mCallback != null) {
+                mHandler.post(() -> mCallback.onLoad());
+            }
+        }
+
+        @JavascriptInterface
         public void onFailure() {
-            if (mOnFailure != null) {
-                new Handler(Looper.getMainLooper()).post(() -> mOnFailure.onFailure());
+            if (mCallback != null) {
+                mHandler.post(() -> mCallback.onFailure());
             }
         }
 
@@ -697,9 +726,10 @@ public class WebFragment extends LazyLoadFragment
                 super.finalize();
             }
         }
-    }
 
-    interface PdfAndroidJavascriptBridgeFailureCallback {
-        void onFailure();
+        interface Callbacks {
+            void onFailure();
+            void onLoad();
+        }
     }
 }


### PR DESCRIPTION
Ticket: https://github.com/hidroh/materialistic/issues/1012

The lifecycle of a PDF document in Materialistic is somewhat different
from a regular HTML page - in the HTML doc, we just open the doc. With
the PDF doc - we first need to download it, then initialize the
renderer, and only then - fetch the pieces we need to render the PDF
pages and actually render them.

Since the current progress bar is just showing loading of the HTML
document, it doesn't show any progress while downloading the PDF, which
is usually the longest part, especially on a slow mobile connection.
Because of that, users may make an assumption the page is broken or
unavailable, though it's just still downloading the PDf doc.

We could solve that by implementing a separate logic for the progress
bar while opening a PDF document. E.g.:

* We figure out this is a PDF doc - we set the progress bar to 10%.
* We finished downloading the PDF doc - we set the progress bar to 80%.
* We finished initializing PDF renderer, and started to fetch chunks of
  PDF doc via the bridge - we set the progress bar to 100%

We could go even further and implement downloading progress, so it'd
correctly progresses from 10 to 80 percent while downloading, but that
would require adding another network interceptor to `Call.Factory` and
way more plumbing than it's necessary for such a small feature.

So, I've done the following changes:

* Added `mIsPdf` field to `WebFragment`, which I use to suppress the
  HTML progress bar logic
* Added another callback to the bridge - onLoad, when it's called, I set
  the progress to 100% and hide the progress bar
* Added updating of the progress bar while processing the PDF doc
  according to the logic I described above
* Moved `PdfAndroidJavascriptBridgeFailureCallback` inside the bridge
  class to make the name shorter

Testing: Opened several HTML and PDF docs, observed the progress bar
behavior