### PR TITLE
Downgrade the html5 `<pre><code>` tags with html4 `<tt>`

### DIFF
--- a/app/src/main/java/io/github/hidroh/materialistic/AppUtils.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/AppUtils.java
@@ -184,16 +184,33 @@ public class AppUtils {
         if (TextUtils.isEmpty(htmlText)) {
             return null;
         }
-        CharSequence spanned;
+        final String replacedText = replacePreCode(htmlText);
+        final CharSequence spanned;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             //noinspection InlinedApi
-            spanned = Html.fromHtml(htmlText, compact ?
+            spanned = Html.fromHtml(replacedText, compact ?
                     Html.FROM_HTML_MODE_COMPACT : Html.FROM_HTML_MODE_LEGACY);
         } else {
             //noinspection deprecation
-            spanned = Html.fromHtml(htmlText);
+            spanned = Html.fromHtml(replacedText);
         }
         return trim(spanned);
+    }
+
+    /**
+     * Replaces occurrences of pre and code tags with the Html.fromHtml supported tt tag.
+     * If the pre/code block contains pre code, then we html encode the pre and code tags.
+     *
+     * @param htmlText The text that possibly contains the tags pre and code
+     * @return The text with tt tags
+     */
+    static String replacePreCode(final String htmlText) {
+        return htmlText
+                .replaceAll("<pre><code>((?s).*?)</code></pre>", "<tt>$1</tt>")
+                .replaceAll("<pre>", "&lt;pre&gt;")
+                .replaceAll("<code>", "&lt;code&gt;")
+                .replaceAll("</pre>", "&lt;/pre&gt;")
+                .replaceAll("</code>", "&lt;/code&gt;");
     }
 
     public static Intent makeSendIntentChooser(Context context, Uri data) {


### PR DESCRIPTION
The textview supports formatting of a few built-in html tags,
`tt` (teletype) is deprecated in html5, but for android this is still implemented

Advantages of this `tt` formatting is that it respects newlines and whitespace using a monospace font,
which makes code formatted comments on Hackernews better readable.

This solution takes a regex and replaces the tags. 
An alternative approach could be to use a html parser library and rewrite the 'raw' text. 
Or implement a `TagHandler` that is being called when the `Html.fromHtml` encounters a tag that it doesn't recognize (`pre` and `code`), however this then involves a lot of `CharSequence` juggling and more or less duplicating the Android standard library that formats the `tt` tag currently. 

Fixes #883