### PR TITLE
Adds a very important note about building in Android Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Run all/selective tests:
 
     ./gradlew jacocoTestReport
 
+Disable `instant run` when building from Android Studio.
+
 ### Articles
 - [Supporting multiple themes in your Android app (Part 1)][article-theme1]
 - [Supporting multiple themes in your Android app (Part 2)][article-theme2] [![][Android Weekly 144 Badge]][Android Weekly 144]


### PR DESCRIPTION
Hey! 

There is an issue building from Android Studio. When we build using `./gradlew assembleDebug` everything is cool, but when trying to build from the IDE, it shows that R8 is disabled and then fails because of different reasons.

Disabling `instant run` seems to fix the build, so I thought it would be useful to add a note in the `README.md`.