### PR TITLE
Update SDK to 30 and add support for transparent status/navigation bars on item view

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "io.github.hidroh.materialistic"
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion 30
         versionCode 79
         versionName "3.3"
@@ -64,6 +64,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0',
             'androidx.recyclerview:recyclerview:1.1.0',
             'androidx.cardview:cardview:1.0.0',
+            'androidx.constraintlayout:constraintlayout:2.0.0',
             'com.google.android.material:material:1.2.0',
             'androidx.preference:preference:1.1.1',
             'androidx.browser:browser:1.2.0',

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "io.github.hidroh.materialistic"
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 79
         versionName "3.3"
         buildConfigField "int", "LATEST_RELEASE", "77"
@@ -25,7 +25,6 @@ android {
     buildTypes {
         debug {
             minifyEnabled !rootProject.ext.ci
-            useProguard false
         }
         release {
             minifyEnabled true
@@ -55,22 +54,19 @@ android {
 }
 
 ext {
-    supportVersion = '28.0.0'
-    okHttpVersion = '3.9.1'
+    okHttpVersion = '4.8.1'
     daggerVersion = '1.2.5'
-    leakCanaryVersion = '1.5.4'
-    retrofitVersion = '2.3.0'
-    roomVersion = '1.0.0'
-    archVersion = '1.1.0'
+    leakCanaryVersion = '1.6.3'
+    retrofitVersion = '2.9.0'
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.0.0',
-            'androidx.recyclerview:recyclerview:1.0.0',
+    implementation 'androidx.appcompat:appcompat:1.2.0',
+            'androidx.recyclerview:recyclerview:1.1.0',
             'androidx.cardview:cardview:1.0.0',
-            'com.google.android.material:material:1.0.0',
-            'androidx.preference:preference:1.0.0',
-            'androidx.browser:browser:1.0.0',
+            'com.google.android.material:material:1.2.0',
+            'androidx.preference:preference:1.1.1',
+            'androidx.browser:browser:1.2.0',
             "com.squareup.dagger:dagger:$daggerVersion",
             "com.squareup.retrofit2:retrofit:$retrofitVersion",
             "com.squareup.retrofit2:converter-gson:$retrofitVersion",
@@ -78,18 +74,20 @@ dependencies {
             "com.squareup.okhttp3:okhttp:$okHttpVersion",
             "com.squareup.okhttp3:logging-interceptor:$okHttpVersion",
             "io.reactivex:rxandroid:1.2.1",
-            "io.reactivex:rxjava:1.1.7",
-            'androidx.room:room-runtime:2.0.0',
-            'androidx.lifecycle:lifecycle-extensions:2.0.0',
-            'androidx.lifecycle:lifecycle-common-java8:2.0.0',
+            'io.reactivex:rxjava:1.3.8',
+            'androidx.room:room-runtime:2.2.5',
+            'androidx.lifecycle:lifecycle-extensions:2.2.0',
+            'androidx.lifecycle:lifecycle-common-java8:2.2.0',
             "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 
     debugImplementation "com.squareup.leakcanary:leakcanary-android${rootProject.hasProperty("leak") ? "" : "-no-op"}:$leakCanaryVersion"
     releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
     testImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"
-    kapt 'androidx.room:room-compiler:2.0.0',
+    kapt 'androidx.room:room-compiler:2.2.5',
             "com.squareup.dagger:dagger-compiler:$daggerVersion"
-    kaptTest 'androidx.room:room-compiler:2.0.0',
+    kaptTest 'androidx.room:room-compiler:2.2.5',
             "com.squareup.dagger:dagger-compiler:$daggerVersion"
 }
 

--- a/app/src/main/java/io/github/hidroh/materialistic/Application.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/Application.java
@@ -19,6 +19,7 @@ package io.github.hidroh.materialistic;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.os.StrictMode;
+
 import androidx.appcompat.app.AppCompatDelegate;
 
 import com.squareup.leakcanary.LeakCanary;

--- a/app/src/main/java/io/github/hidroh/materialistic/ItemFragment.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/ItemFragment.java
@@ -116,6 +116,10 @@ public class ItemFragment extends LazyLoadFragment implements Scrollable, Naviga
             mRecyclerView.setLayoutManager(new SnappyLinearLayoutManager(getActivity(), true));
             mItemDecoration = new CommentItemDecoration(getActivity());
             mRecyclerView.addItemDecoration(mItemDecoration);
+            mRecyclerView.setOnApplyWindowInsetsListener((view, windowInsets) -> {
+                view.setPadding(0, 0, 0, windowInsets.getSystemWindowInsetBottom());
+                return windowInsets;
+            });
             mSwipeRefreshLayout = (SwipeRefreshLayout) mFragmentView.findViewById(R.id.swipe_layout);
             mSwipeRefreshLayout.setColorSchemeResources(R.color.white);
             mSwipeRefreshLayout.setProgressBackgroundColorSchemeResource(R.color.redA200);

--- a/app/src/main/java/io/github/hidroh/materialistic/WebFragment.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/WebFragment.java
@@ -30,6 +30,7 @@ import android.os.Handler;
 import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -157,6 +158,10 @@ public class WebFragment extends LazyLoadFragment
             mEditText = (EditText) mFragmentView.findViewById(R.id.edittext);
             setUpWebControls(mFragmentView);
             setUpWebView(mFragmentView);
+            mScrollViewContent.setOnApplyWindowInsetsListener((View.OnApplyWindowInsetsListener) (view, windowInsets) -> {
+                mScrollViewContent.setPadding(0, 0, 0, windowInsets.getSystemWindowInsetBottom());
+                return windowInsets;
+            });
         }
         return mFragmentView;
     }

--- a/app/src/main/java/io/github/hidroh/materialistic/data/FavoriteManager.kt
+++ b/app/src/main/java/io/github/hidroh/materialistic/data/FavoriteManager.kt
@@ -34,6 +34,8 @@ import io.github.hidroh.materialistic.ktx.getUri
 import io.github.hidroh.materialistic.ktx.setChannel
 import io.github.hidroh.materialistic.ktx.toSendIntentChooser
 import okio.Okio
+import okio.buffer
+import okio.sink
 import rx.Observable
 import rx.Scheduler
 import rx.android.schedulers.AndroidSchedulers
@@ -205,7 +207,7 @@ class FavoriteManager @Inject constructor(
     if (!dir.exists() && !dir.mkdir()) return null
     val file = File(dir, FILENAME_EXPORT)
     if (!file.exists() && !file.createNewFile()) return null
-    val bufferedSink = Okio.buffer(Okio.sink(file))
+    val bufferedSink = file.sink().buffer()
     with(bufferedSink) {
       do {
         val item = cursor.favorite

--- a/app/src/main/java/io/github/hidroh/materialistic/data/MaterialisticDatabase.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/data/MaterialisticDatabase.java
@@ -23,6 +23,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import java.util.List;
+import java.util.Objects;
 
 @Database(
         entities = {
@@ -132,7 +133,7 @@ public abstract class MaterialisticDatabase extends RoomDatabase {
             ReadStory readStory = (ReadStory) o;
 
             if (id != readStory.id) return false;
-            return itemId != null ? itemId.equals(readStory.itemId) : readStory.itemId == null;
+            return Objects.equals(itemId, readStory.itemId);
         }
 
         @Override
@@ -189,9 +190,7 @@ public abstract class MaterialisticDatabase extends RoomDatabase {
             Readable readable = (Readable) o;
 
             if (id != readable.id) return false;
-            if (itemId != null ? !itemId.equals(readable.itemId) : readable.itemId != null)
-                return false;
-            return content != null ? content.equals(readable.content) : readable.content == null;
+            return Objects.equals(content, readable.content);
         }
 
         @Override

--- a/app/src/main/java/io/github/hidroh/materialistic/ktx/Extensions.kt
+++ b/app/src/main/java/io/github/hidroh/materialistic/ktx/Extensions.kt
@@ -24,11 +24,11 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.content.FileProvider
 import io.github.hidroh.materialistic.AppUtils
-import okhttp3.internal.Util
+import okhttp3.internal.closeQuietly
 import java.io.Closeable
 import java.io.File
 
-inline fun Closeable.closeQuietly() = Util.closeQuietly(this)
+inline fun Closeable.closeQuietly() = this.closeQuietly()
 
 inline fun File.getUri(context: Context, authority: String) =
     FileProvider.getUriForFile(context, authority, this)!!

--- a/app/src/main/res/layout/activity_item.xml
+++ b/app/src/main/res/layout/activity_item.xml
@@ -33,14 +33,12 @@
             android:theme="@style/AppToolbarTheme"
             android:layout_height="wrap_content"
             android:layout_width="match_parent"
-            android:minHeight="0dp"
             app:layout_scrollFlags="scroll|enterAlwaysCollapsed"
             android:background="?attr/colorPrimary" />
 
         <include layout="@layout/item_header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:minHeight="0dp"
             app:layout_scrollFlags="scroll|enterAlwaysCollapsed"
             android:id="@id/header_card_view" />
 
@@ -49,7 +47,7 @@
             app:tabTextColor="?android:attr/textColorPrimary"
             app:layout_scrollFlags="scroll|snap|enterAlways"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="wrap_content" />
 
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/layout/fragment_item.xml
+++ b/app/src/main/res/layout/fragment_item.xml
@@ -31,7 +31,8 @@
             android:id="@id/recycler_view"
             android:scrollbars="vertical"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            android:clipToPadding="false" />
 
         <include layout="@layout/empty_item"
                  android:layout_height="match_parent"

--- a/app/src/main/res/layout/item_header.xml
+++ b/app/src/main/res/layout/item_header.xml
@@ -15,41 +15,40 @@
   ~ limitations under the License.
   -->
 
-<RelativeLayout
+
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@id/header_card_view"
-    android:paddingTop="@dimen/margin"
-    android:paddingBottom="@dimen/margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingVertical="@dimen/margin"
+    android:paddingHorizontal="@dimen/activity_horizontal_margin"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     tools:background="?attr/colorPrimary">
+
     <io.github.hidroh.materialistic.widget.TextView
         android:id="@android:id/text2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:text="@string/loading_text"
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
         android:maxLines="@integer/header_max_lines"
         android:textAppearance="@style/TextAppearance.AppCompat.Widget.ActionBar.Title"
         android:textSize="?attr/titleTextSize"
         android:ellipsize="end"
-        android:layout_alignParentTop="true"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-    <LinearLayout
-        android:id="@+id/meta_container"
-        android:orientation="vertical"
-        android:gravity="center_vertical"
-        android:layout_below="@android:id/text2"
-        android:layout_toLeftOf="@+id/action_container"
-        android:layout_toStartOf="@+id/action_container"
-        android:layout_alignTop="@id/action_container"
-        android:layout_alignBottom="@id/action_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/source_time_buttons_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@android:id/text2">
 
         <TextView
             android:id="@id/source"
@@ -62,7 +61,12 @@
             android:textAppearance="@style/TextAppearance.AppCompat.Widget.ActionBar.Subtitle"
             android:textColor="?android:attr/textColorPrimary"
             android:textSize="?attr/subtitleTextSize"
-            android:textStyle="italic" />
+            android:textStyle="italic"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/vote_button"
+            app:layout_constraintBottom_toTopOf="@id/posted"
+            app:layout_constraintVertical_chainStyle="packed"/>
 
         <TextView
             android:id="@id/posted"
@@ -73,18 +77,12 @@
             android:layout_height="wrap_content"
             android:textAppearance="@style/TextAppearance.AppCompat.Widget.ActionBar.Subtitle"
             android:textSize="?attr/subtitleTextSize"
-            android:textColor="?android:attr/textColorPrimary"/>
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@id/action_container"
-        android:orientation="horizontal"
-        android:gravity="center_vertical"
-        android:layout_below="@android:id/text2"
-        android:layout_alignParentRight="true"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+            android:textColor="?android:attr/textColorPrimary"
+            app:layout_constraintTop_toBottomOf="@id/source"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/vote_button"
+            app:layout_constraintVertical_chainStyle="packed"/>
 
         <io.github.hidroh.materialistic.widget.IconButton
             android:id="@+id/vote_button"
@@ -93,9 +91,12 @@
             android:visibility="invisible"
             android:src="@drawable/ic_thumb_up_white_24dp"
             android:padding="@dimen/padding"
-            android:layout_margin="@dimen/margin"
+            android:layout_marginHorizontal="@dimen/margin"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/bookmarked"/>
 
         <io.github.hidroh.materialistic.widget.IconButton
             android:id="@id/bookmarked"
@@ -104,30 +105,28 @@
             tools:visibility="visible"
             android:src="@drawable/ic_bookmark_border_white_24dp"
             android:padding="@dimen/padding"
-            android:layout_margin="@dimen/margin"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
 
-    </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <io.github.hidroh.materialistic.widget.TintableTextView
         android:id="@+id/button_article"
         android:text="@string/article"
-        android:layout_below="@id/meta_container"
         app:iconEnd="@drawable/ic_open_in_browser_white_24dp"
         android:gravity="center_vertical"
         android:drawablePadding="@dimen/padding"
         android:background="?attr/selectableItemBackground"
-        android:paddingLeft="24dp"
-        android:paddingStart="24dp"
-        android:paddingRight="24dp"
-        android:paddingEnd="24dp"
-        android:layout_alignRight="@+id/action_container"
-        android:layout_alignEnd="@+id/action_container"
+        android:padding="@dimen/padding"
         android:visibility="gone"
         tools:visibility="visible"
         app:textAllCaps="true"
         android:layout_width="wrap_content"
-        android:layout_height="?attr/listPreferredItemHeightSmall" />
+        android:layout_height="?attr/listPreferredItemHeightSmall"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/source_time_buttons_container" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -64,4 +64,6 @@
 
     <color name="cardDarkBackground">#FF424242</color>
 
+    <color name="status_bar_background">#52000000</color>
+
 </resources>

--- a/app/src/main/res/values/non_translatable.xml
+++ b/app/src/main/res/values/non_translatable.xml
@@ -79,7 +79,7 @@
                         actively working on an alternative solution for this.
                     </li>
                     <li>
-                        Certain websites don't load or show up blank in-app. You can try to disable
+                        Certain websites don\'t load or show up blank in-app. You can try to disable
                         in-app ad blocker to see if it helps. At the same time please file a feedback
                         with the website/article that fails to load so it can be fixed!
                     </li>

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.4.0'
 
     repositories {
         maven { url 'https://maven.google.com' }
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 18 12:33:25 EST 2019
+#Fri Aug 28 10:10:01 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -11,7 +11,7 @@ task jacocoTestReport(type: JacocoReport) {
         html.destination file("${buildDir}/reports/coverage")
     }
 
-    classDirectories = fileTree(
+    classDirectories.from = fileTree(
             dir: "${buildDir}/intermediates/classes/debug",
             exclude: [
                     '**/R.class',
@@ -36,8 +36,8 @@ task jacocoTestReport(type: JacocoReport) {
                     '**/*Dummy*.class',
                     '**/*ItemDecoration.class'
             ])
-    sourceDirectories = files android.sourceSets.main.java.srcDirs
-    executionData = files "${buildDir}/jacoco/testDebugUnitTest.exec"
+    sourceDirectories.from = files android.sourceSets.main.java.srcDirs
+    executionData.from = files "${buildDir}/jacoco/testDebugUnitTest.exec"
 
     // Bit hacky but fixes https://code.google.com/p/android/issues/detail?id=69174.
     // We iterate through the compiled .class tree and rename $$ to $.


### PR DESCRIPTION
This PR updates the SDK to 30 and changes the item view to support transparent status/navigation bars. The min SDK needed for this is 21 (which seems reasonable as a min sdk version). See video for a demo of how this works.

I want to also add support for this to the main item list screen, but that requires more work and some refactoring.

![2020-09-13_17-08-22](https://user-images.githubusercontent.com/443370/93032046-0a288e00-f5e4-11ea-9328-e5df85c772cf.gif)
