### PR TITLE
Allow user to vote comments down

### DIFF
--- a/app/src/main/java/io/github/hidroh/materialistic/accounts/UserServices.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/accounts/UserServices.java
@@ -46,6 +46,8 @@ public interface UserServices {
 
     boolean voteUp(Context context, String itemId, Callback callback);
 
+    boolean voteDown(Context context, String itemId, Callback callback);
+
     void reply(Context context, String parentId, String text, Callback callback);
 
     void submit(Context context, String title, String content, boolean isUrl, Callback callback);

--- a/app/src/main/java/io/github/hidroh/materialistic/accounts/UserServicesClient.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/accounts/UserServicesClient.java
@@ -63,6 +63,7 @@ public class UserServicesClient implements UserServices {
     private static final String SUBMIT_PARAM_FNID = "fnid";
     private static final String SUBMIT_PARAM_FNOP = "fnop";
     private static final String VOTE_DIR_UP = "up";
+    private static final String VOTE_DIR_DOWN = "down";
     private static final String DEFAULT_REDIRECT = "news";
     private static final String CREATING_TRUE = "t";
     private static final String DEFAULT_FNOP = "submit-page";
@@ -102,7 +103,21 @@ public class UserServicesClient implements UserServices {
             return false;
         }
         Toast.makeText(context, R.string.sending, Toast.LENGTH_SHORT).show();
-        execute(postVote(credentials.first, credentials.second, itemId))
+        execute(postVoteUp(credentials.first, credentials.second, itemId))
+                .map(response -> response.code() == HttpURLConnection.HTTP_MOVED_TEMP)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(callback::onDone, callback::onError);
+        return true;
+    }
+
+    @Override
+    public boolean voteDown(Context context, String itemId, Callback callback) {
+        Pair<String, String> credentials = AppUtils.getCredentials(context);
+        if (credentials == null) {
+            return false;
+        }
+        Toast.makeText(context, R.string.sending, Toast.LENGTH_SHORT).show();
+        execute(postVoteDown(credentials.first, credentials.second, itemId))
                 .map(response -> response.code() == HttpURLConnection.HTTP_MOVED_TEMP)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(callback::onDone, callback::onError);
@@ -190,7 +205,15 @@ public class UserServicesClient implements UserServices {
                 .build();
     }
 
-    private Request postVote(String username, String password, String itemId) {
+    private Request postVoteUp(String username, String password, String itemId) {
+        return postVote(username, password, itemId, VOTE_DIR_UP);
+    }
+
+    private Request postVoteDown(String username, String password, String itemId) {
+        return postVote(username, password, itemId, VOTE_DIR_DOWN);
+    }
+
+    private Request postVote(String username, String password, String itemId, String upOrDown) {
         return new Request.Builder()
                 .url(HttpUrl.parse(BASE_WEB_URL)
                         .newBuilder()
@@ -200,10 +223,11 @@ public class UserServicesClient implements UserServices {
                         .add(LOGIN_PARAM_ACCT, username)
                         .add(LOGIN_PARAM_PW, password)
                         .add(VOTE_PARAM_ID, itemId)
-                        .add(VOTE_PARAM_HOW, VOTE_DIR_UP)
+                        .add(VOTE_PARAM_HOW, upOrDown)
                         .build())
                 .build();
     }
+
 
     private Request postReply(String parentId, String text, String username, String password) {
         return new Request.Builder()

--- a/app/src/main/java/io/github/hidroh/materialistic/widget/FavoriteRecyclerViewAdapter.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/widget/FavoriteRecyclerViewAdapter.java
@@ -273,7 +273,7 @@ public class FavoriteRecyclerViewAdapter extends ListRecyclerViewAdapter
         mPopupMenu.create(mContext, v, Gravity.NO_GRAVITY)
                 .inflate(R.menu.menu_contextual_favorite)
                 .setOnMenuItemClickListener(menuItem -> {
-                    if (menuItem.getItemId() == R.id.menu_contextual_vote) {
+                    if (menuItem.getItemId() == R.id.menu_contextual_vote_up) {
                         vote(item);
                         return true;
                     }

--- a/app/src/main/java/io/github/hidroh/materialistic/widget/ItemRecyclerViewAdapter.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/widget/ItemRecyclerViewAdapter.java
@@ -234,8 +234,12 @@ public abstract class ItemRecyclerViewAdapter<VH extends ItemRecyclerViewAdapter
             mPopupMenu.create(mContext, holder.mMoreButton, Gravity.NO_GRAVITY)
                 .inflate(R.menu.menu_contextual_comment)
                 .setOnMenuItemClickListener(menuItem -> {
-                    if (menuItem.getItemId() == R.id.menu_contextual_vote) {
-                        vote(item);
+                    if (menuItem.getItemId() == R.id.menu_contextual_vote_up) {
+                        voteUp(item);
+                        return true;
+                    }
+                    if (menuItem.getItemId() == R.id.menu_contextual_vote_down) {
+                        voteDown(item);
                         return true;
                     }
                     if (menuItem.getItemId() == R.id.menu_contextual_comment) {
@@ -257,8 +261,12 @@ public abstract class ItemRecyclerViewAdapter<VH extends ItemRecyclerViewAdapter
                 .show());
     }
 
-    private void vote(final Item item) {
+    private void voteUp(final Item item) {
         mUserServices.voteUp(mContext, item.getId(), new VoteCallback(this));
+    }
+
+    private void voteDown(final Item item) {
+        mUserServices.voteDown(mContext, item.getId(), new VoteCallback(this));
     }
 
     @Synthetic

--- a/app/src/main/java/io/github/hidroh/materialistic/widget/StoryRecyclerViewAdapter.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/widget/StoryRecyclerViewAdapter.java
@@ -442,7 +442,7 @@ public class StoryRecyclerViewAdapter extends
                         story.isFavorite() ? R.string.unsave : R.string.save)
                 .setMenuItemVisible(R.id.menu_contextual_save,
                         !mCallback.hasAction(Preferences.SwipeAction.Save))
-                .setMenuItemVisible(R.id.menu_contextual_vote,
+                .setMenuItemVisible(R.id.menu_contextual_vote_up,
                         !mCallback.hasAction(Preferences.SwipeAction.Vote))
                 .setMenuItemVisible(R.id.menu_contextual_refresh,
                         !mCallback.hasAction(Preferences.SwipeAction.Refresh))
@@ -451,7 +451,7 @@ public class StoryRecyclerViewAdapter extends
                         toggleSave(story);
                         return true;
                     }
-                    if (item.getItemId() == R.id.menu_contextual_vote) {
+                    if (item.getItemId() == R.id.menu_contextual_vote_up) {
                         vote(story, holder);
                         return true;
                     }

--- a/app/src/main/res/menu/menu_contextual_comment.xml
+++ b/app/src/main/res/menu/menu_contextual_comment.xml
@@ -17,8 +17,11 @@
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@id/menu_contextual_vote"
+        android:id="@id/menu_contextual_vote_up"
         android:title="@string/vote_up" />
+    <item
+        android:id="@id/menu_contextual_vote_down"
+        android:title="@string/vote_down" />
     <item
         android:id="@id/menu_contextual_comment"
         android:title="@string/add_comment" />

--- a/app/src/main/res/menu/menu_contextual_favorite.xml
+++ b/app/src/main/res/menu/menu_contextual_favorite.xml
@@ -17,7 +17,7 @@
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@id/menu_contextual_vote"
+        android:id="@id/menu_contextual_vote_up"
         android:title="@string/vote_up" />
     <item
         android:id="@id/menu_contextual_comment"

--- a/app/src/main/res/menu/menu_contextual_story.xml
+++ b/app/src/main/res/menu/menu_contextual_story.xml
@@ -20,7 +20,7 @@
         android:id="@id/menu_contextual_save"
         android:title="@string/save" />
     <item
-        android:id="@id/menu_contextual_vote"
+        android:id="@id/menu_contextual_vote_up"
         android:title="@string/vote_up" />
     <item
         android:id="@id/menu_contextual_refresh"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -191,6 +191,7 @@
     <string name="unsave">Quitar de guardados</string>
     <string name="re_enter_password">Vuelve a escribir tu contraseña</string>
     <string name="vote_up">Votar arriba</string>
+    <string name="vote_down">Votar abajo</string>
     <string name="voted">Votada correctamente</string>
     <string name="vote_failed">Ha sido imposible contabilizar tu voto. Intentalo de nuevo por favor.</string>
     <string name="sending">Enviando…</string>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -84,7 +84,8 @@
     <item type="id" name="menu_sort_popular" />
     <item type="id" name="menu_list" />
     <item type="id" name="menu_contextual_save" />
-    <item type="id" name="menu_contextual_vote" />
+    <item type="id" name="menu_contextual_vote_up" />
+    <item type="id" name="menu_contextual_vote_down" />
     <item type="id" name="menu_contextual_refresh" />
     <item type="id" name="menu_contextual_comment" />
     <item type="id" name="menu_contextual_profile" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,6 +238,7 @@
     <string name="unsave">Unsave</string>
     <string name="re_enter_password">Re-enter your password</string>
     <string name="vote_up">Vote up</string>
+    <string name="vote_down">Vote down</string>
     <string name="voted">Successfully voted</string>
     <string name="vote_failed">Fail to record vote. Please try again.</string>
     <string name="sending" tools:ignore="TypographyEllipsis">Sending...</string>

--- a/app/src/test/java/io/github/hidroh/materialistic/FavoriteActivityTest.java
+++ b/app/src/test/java/io/github/hidroh/materialistic/FavoriteActivityTest.java
@@ -302,7 +302,7 @@ public class FavoriteActivityTest {
         PopupMenu popupMenu = ShadowPopupMenu.getLatestPopupMenu();
         Assert.assertNotNull(popupMenu);
         shadowOf(popupMenu).getOnMenuItemClickListener()
-                .onMenuItemClick(new RoboMenuItem(R.id.menu_contextual_vote));
+                .onMenuItemClick(new RoboMenuItem(R.id.menu_contextual_vote_up));
         verify(userServices).voteUp(any(Context.class), any(), userServicesCallback.capture());
         userServicesCallback.getValue().onDone(true);
         assertEquals(activity.getString(R.string.voted), ShadowToast.getTextOfLatestToast());
@@ -315,7 +315,7 @@ public class FavoriteActivityTest {
         PopupMenu popupMenu = ShadowPopupMenu.getLatestPopupMenu();
         Assert.assertNotNull(popupMenu);
         shadowOf(popupMenu).getOnMenuItemClickListener()
-                .onMenuItemClick(new RoboMenuItem(R.id.menu_contextual_vote));
+                .onMenuItemClick(new RoboMenuItem(R.id.menu_contextual_vote_up));
         verify(userServices).voteUp(any(Context.class), any(), userServicesCallback.capture());
         userServicesCallback.getValue().onDone(false);
         assertThat(shadowOf(activity).getNextStartedActivity())
@@ -329,7 +329,7 @@ public class FavoriteActivityTest {
         PopupMenu popupMenu = ShadowPopupMenu.getLatestPopupMenu();
         Assert.assertNotNull(popupMenu);
         shadowOf(popupMenu).getOnMenuItemClickListener()
-                .onMenuItemClick(new RoboMenuItem(R.id.menu_contextual_vote));
+                .onMenuItemClick(new RoboMenuItem(R.id.menu_contextual_vote_up));
         verify(userServices).voteUp(any(Context.class), any(), userServicesCallback.capture());
         userServicesCallback.getValue().onError(new IOException());
         assertEquals(activity.getString(R.string.vote_failed), ShadowToast.getTextOfLatestToast());


### PR DESCRIPTION
Closes #399.

Keep in mind that doing:
1. vote up
2. (then) vote down

or the reverse does not work (meaning that the second vote has no effect). Switching from one vote to another requires unvoting first, from my few experiments. AFAICT, unvoting is currently not implemented in materialistic (it's just `how=un`). I think it's fine, let me know otherwise.